### PR TITLE
Prevent clipping for .App

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -1,6 +1,11 @@
 .App {
     display: flex;
     align-items: center;
+    flex-direction: column;
+    flex-wrap: wrap;
+    height: auto;
     justify-content: center;
-    height: 100vh;
+    min-height: 100%;
+    min-width: 100%;
+    width: auto;
 }

--- a/src/index.css
+++ b/src/index.css
@@ -8,6 +8,11 @@ body {
     background: #282c34;
 }
 
+body, html, #root {
+    height: 100%;
+    width: 100%;
+}
+
 code {
     font-family: source-code-pro, Menlo, Monaco, Consolas, "Courier New",
         monospace;


### PR DESCRIPTION
Adjust the `.App` div and its parent containers to allow the user to scroll to the top and left side of the content when it is larger than the viewport.

This fixes #80.

While this PR is under review, a userstyle is also available:
https://github.com/remino/userscripts/blob/main/userstyles/infinite-mac-scroll-fix.user.css
