### PR TITLE
Add disclaimer to LICENCE

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,3 +1,5 @@
+Disclaimer: this licence only applies for the code of the Infinite Mac site itself. All programs on the emulators/simulators, CD-ROMs, the emulators themselves, and operating systems on the site have their own licenses. All variations of the Apple logo and the terms Apple, Macintosh, Mac, Mac OS, macOS, iOS, iPhone, iPod, Power Mac, iMac, and all other terms on https://www.apple.com/legal/intellectual-property/trademark/appletmlist.html are property of Apple Inc. and the term PowerPC is property of IBM. 
+
 Apache License
                            Version 2.0, January 2004
                         http://www.apache.org/licenses/

--- a/LICENSE
+++ b/LICENSE
@@ -1,4 +1,4 @@
-Disclaimer: this licence only applies for the code of the Infinite Mac site itself. All programs on the emulators/simulators, CD-ROMs, the emulators themselves, and operating systems on the site have their own licenses. All variations of the Apple logo and the terms Apple, Macintosh, Mac, Mac OS, macOS, iOS, iPhone, iPod, Power Mac, iMac, and all other terms on https://www.apple.com/legal/intellectual-property/trademark/appletmlist.html are property of Apple Inc. and the term PowerPC is property of IBM. 
+Disclaimer: this licence only applies for the code of the Infinite Mac site itself. All programs on the emulators/simulators, CD-ROMs, the emulators themselves, and operating systems on the site have their own licenses. All variations of the Apple logo and the terms Apple, Macintosh, Mac, Mac OS, macOS, iOS, iPhone, iPod, Power Mac, PowerBook, iMac, iBook, and all other terms and logos listed on https://www.apple.com/legal/intellectual-property/trademark/appletmlist.html are property of Apple Inc. and the term PowerPC is property of IBM. 
 
 Apache License
                            Version 2.0, January 2004


### PR DESCRIPTION
The new disclaimer states that the licence does not apply to any operating systems, software, CD-ROMs, and emulators on the site and lists trademarked names and logos.