### PR TITLE
Update MacTech CD-ROM archive.org's links to Volumes 1-17 (2001)

### DIFF
--- a/CD-ROMs/Developer/MacTech CD-ROM Volumes 1-12.json
+++ b/CD-ROMs/Developer/MacTech CD-ROM Volumes 1-12.json
@@ -1,5 +1,0 @@
-{
-    "src_url": "https://archive.org/download/MacTechVol112/MacTech-vol-1-12.toast",
-    "cover_image": "https://web.archive.org/web/20000816062450if_/http://www.mactech.com:80/cdrom/MTCD15.gif",
-    "cover_image_type": "square"
-}

--- a/CD-ROMs/Developer/MacTech CD-ROM Volumes 1-17.json
+++ b/CD-ROMs/Developer/MacTech CD-ROM Volumes 1-17.json
@@ -1,0 +1,5 @@
+{
+    "src_url": "https://archive.org/download/mac-tech-cd-v-1-17/MacTech_CD_v1-17.toast",
+    "cover_image": "https://web.archive.org/web/20060712224824im_/http://store.mactech.com/images/ProductImages/SMTCD.JPG",
+    "cover_image_type": "square"
+}


### PR DESCRIPTION
On archive.org there is available a newer edition of the MacTech CD-ROM (Volumes 1-17, April 2001): https://archive.org/details/mac-tech-cd-v-1-17 . 