### PR TITLE
Fix copy/paste error

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,4 +137,4 @@ emcmake cmake -DCMAKE_BUILD_TYPE=Release -DENABLE_RENDERING_THREAD=0 ..
 make previous -j8
 ```
 
-Once it has built, use `npm run import-emulator dingusppc` from the host to update the files in `src/emulator`.
+Once it has built, use `npm run import-emulator previous` from the host to update the files in `src/emulator`.


### PR DESCRIPTION
It looks like the new instructions for `previous` were pasted without updating the parameter to `import-emulator`