### PR TITLE
Send the parent a message when the emulator is fully loaded.

### DIFF
--- a/src/Mac.tsx
+++ b/src/Mac.tsx
@@ -263,6 +263,14 @@ export default function Mac({
                             )
                         );
                     }
+                    if (listenForControlMessages) {
+                        window.parent.postMessage(
+                            {
+                                type: "emulator_loaded",
+                            },
+                            "*"
+                        );
+                    }
                 },
                 emulatorDidMakeLoadingProgress(
                     emulator: Emulator,


### PR DESCRIPTION
Sends a message when the emulator is an embed and fully loaded. Useful for the parent to know when the parent is ready to receive pause/unpause messages, and generally if everything went ok.